### PR TITLE
Version 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,25 +10,7 @@
    npm i next-google-fonts
    ```
 
-2. If you haven't already, [create a custom `_app.jsx` or `_app.tsx`](https://nextjs.org/docs/advanced-features/custom-app).
-3. Wrap the `Component` with the `GoogleFontsProvider` and pass your Google Fonts URL via the `href` attribute:
-
-   ```tsx
-   // pages/_app.tsx
-   import * as React from "react";
-   import { AppProps } from "next/app";
-   import { GoogleFontsProvider } from "next-google-fonts";
-
-   const App = ({ Component, pageProps }: AppProps) => (
-     <GoogleFontsProvider href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap">
-       <Component {...pageProps} />
-     </GoogleFontsProvider>
-   );
-
-   export default App;
-   ```
-
-4. Place `GoogleFonts` wherever it's required; whether it's a component, one-off page or a custom `Head` component.
+2. Place `GoogleFonts` wherever it's required—whether it's a component, one-off page or a custom `Head` component—and pass your Google Fonts URL via the `href` attribute:
 
    For a custom TypeScript `Head` component that may look something like this:
 
@@ -36,13 +18,13 @@
    // components/head.tsx
    import * as React from "react";
    import NextHead from "next/head";
-   import { GoogleFonts } from "next-google-fonts";
+   import GoogleFonts from "next-google-fonts";
 
    export const Head: React.FC<{
      title?: string;
    }> = ({ children, title }) => (
      <React.Fragment>
-       <GoogleFonts />
+       <GoogleFonts href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" />
        <NextHead>
          <meta charSet="UTF-8" />
          <meta
@@ -61,7 +43,7 @@
 
    > It's very important to remember that `GoogleFonts` is a small [`next/head`][next/head] component and should **not** be nested inside [`next/head`][next/head]. To solve this, wrap both components with a `Fragment`.
 
-5. Add the requested Google Font/s to your styles with a sensible fallback.  
+3. Add the requested Google Font/s to your styles with a sensible fallback.  
    It really doesn't matter whether you're using CSS or Sass or CSS-in-JS:
 
    ```css
@@ -70,8 +52,8 @@
    }
    ```
 
-6. [Run your Next.js app](https://nextjs.org/docs/api-reference/cli#build) to see the results in action!  
-   You should expect to see the fallback font first, followed by a switch to the Google Font/s without any render-blocking CSS warnings.  
+4. [Run your Next.js app](https://nextjs.org/docs/api-reference/cli#build) to see the results in action!  
+   You should expect to see the fallback font first, followed by a switch to the Google Font/s without any render-blocking CSS warnings. Your font will persist in the client-side cache thanks to [SWR](https://swr.now.sh/).  
    If JS is disabled, only the fallback font will display.
 
 ## Why?

--- a/package-lock.json
+++ b/package-lock.json
@@ -9729,6 +9729,21 @@
         "util.promisify": "~1.0.0"
       }
     },
+    "swr": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-0.2.2.tgz",
+      "integrity": "sha512-D/z+PTUchZhoUA0tNC8TNJivf7Hc61WPxbUdXPi+VxRloddWYNP1ZicaEgyAph42ZnKl1L7twcZr4q6d0UMXcg==",
+      "requires": {
+        "fast-deep-equal": "2.0.1"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+        }
+      }
+    },
     "tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -57,5 +57,8 @@
     "microbundle": "0.12.0",
     "prettier": "2.0.5",
     "typescript": "3.9.3"
+  },
+  "dependencies": {
+    "swr": "0.2.2"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import Head from "next/head";
+import useSWR from "swr";
 
-type Href = {
+export type GoogleFontsProps = {
   /**
    * URL to your Google Fonts StyleSheet.
    *
@@ -10,30 +11,14 @@ type Href = {
   href: string;
 };
 
-type HasLoaded = boolean;
-
-export const GoogleFontsContext = React.createContext<
-  {
-    hasLoaded?: HasLoaded;
-  } & Href
->(undefined);
-
-export const GoogleFontsProvider: React.FC<Href> = ({ href, children }) => {
-  const [hasLoaded, setHasLoaded] = React.useState<HasLoaded>(false);
+const GoogleFonts: React.FC<GoogleFontsProps> = ({ href }) => {
+  const { data: hasLoaded, mutate: setHasLoaded } = useSWR("hasLoaded", {
+    initialData: false,
+  });
 
   React.useEffect(() => {
     setHasLoaded(true);
   }, []);
-
-  return (
-    <GoogleFontsContext.Provider value={{ hasLoaded: hasLoaded, href: href }}>
-      {children}
-    </GoogleFontsContext.Provider>
-  );
-};
-
-export const GoogleFonts: React.FC = () => {
-  const useGoogleFonts = React.useContext(GoogleFontsContext);
 
   return (
     <Head>
@@ -42,12 +27,10 @@ export const GoogleFonts: React.FC = () => {
         href="https://fonts.gstatic.com"
         crossOrigin="anonymous"
       />
-      <link rel="preload" as="style" href={useGoogleFonts.href} />
-      <link
-        href={useGoogleFonts.href}
-        rel="stylesheet"
-        media={!useGoogleFonts.hasLoaded ? "print" : "all"}
-      />
+      <link rel="preload" as="style" href={href} />
+      <link href={href} rel="stylesheet" media={!hasLoaded ? "print" : "all"} />
     </Head>
   );
 };
+
+export default GoogleFonts;


### PR DESCRIPTION
I've been playing around with this in a few projects and I'm pretty happy with the behaviour, but not overly keen on the idea of having to set up a custom `_app.tsx` and wrapping it with a context to use this plugin.

I recently came across @pacocoursey's ["Shared Hook State with SWR"](https://paco.im/blog/shared-hook-state-with-swr) and used this under-the-hood to create my ideal API for this plugin: **one import, low set-up**.

This has been tested on my personal site: [joebell.co.uk](joebell.co.uk/) and I'm confident it's the best approach going forwards.

I'll add a migration guide in the release notes!