### PR TITLE
feat: add "no-js" fallback

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,6 +33,9 @@ const GoogleFonts: React.FC<GoogleFontsProps> = ({ href }) => {
       />
       <link rel="preload" as="style" href={href} />
       <link href={href} rel="stylesheet" media={!hydrated ? "print" : "all"} />
+      <noscript>
+        <link href={href} rel="stylesheet" />
+      </noscript>
     </Head>
   );
 };


### PR DESCRIPTION
From senpai [Harry Roberts](https://csswizardry.com/2020/05/the-fastest-google-fonts/#google-fonts-async-snippet):

> In the unlikely event that a visitor has intentionally disabled JavaScript, fall back to the original method. The good news is that, although this is a render-blocking request, it can still make use of the preconnect which makes it marginally faster than the default.