### PR TITLE
Add experimental `future` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,6 @@
 
 > Using Next.js 10? See ["How does this compare to Next.js font optimization?"](#how-does-this-compare-to-nextjs-font-optimization) before continuing.
 
-## Table of Contents
-
-1. [Setup](#setup)
-2. [FAQs](#faqs)
-
 ## Setup
 
 In this example, we're going to add [`Inter`](https://fonts.google.com/specimen/Inter) (specifically weights `400` and `700`) to a Next.js app.
@@ -89,6 +84,16 @@ See [joebell.co.uk](https://joebell.co.uk) for a working example.
    You should expect to see the fallback font first, followed by a switch to the Google Font/s without any render-blocking CSS warnings. Your font/s will continue to display until your app is re-hydrated.
 
    If JS is disabled, only the fallback font will display.
+
+## Upcoming Changes
+
+You can opt-in to upcoming changes via the `future` prop.
+
+### `withoutHead`
+
+Currently, `next-google-fonts` sits inside Next.js' `<Head>` component; meaning it can't be nested inside a consumer's `<Head>`.
+
+This behavior will change in an upcoming release, and `GoogleFonts` will **need** to be placed inside `<Head>` on the consumer's side.
 
 ## FAQs
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,11 +8,23 @@ export interface IGoogleFontsProps {
    * Be sure to end with `&display=swap` for best performance.
    */
   href: string;
+  /**
+   * **UNSTABLE**
+   *
+   * Opt-in to upcoming changes ahead of the `v3` release.
+   */
+  future?: {
+    /**
+     * `GoogleFonts` no longer sits inside `<Head>`, you'll need to do this on
+     * your side instead.
+     */
+    withoutHead?: boolean;
+  };
 }
 
 let hydrated = false;
 
-export const GoogleFonts: React.FC<IGoogleFontsProps> = ({ href }) => {
+const GoogleFontsTags: React.FC<IGoogleFontsProps> = ({ href }) => {
   const hydratedRef = React.useRef(false);
   const [, rerender] = React.useState(false);
 
@@ -25,7 +37,7 @@ export const GoogleFonts: React.FC<IGoogleFontsProps> = ({ href }) => {
   }, []);
 
   return (
-    <Head>
+    <React.Fragment>
       <link
         rel="preconnect"
         href="https://fonts.gstatic.com"
@@ -55,6 +67,15 @@ export const GoogleFonts: React.FC<IGoogleFontsProps> = ({ href }) => {
           key="next-google-fonts__style-no-js"
         />
       </noscript>
-    </Head>
+    </React.Fragment>
   );
 };
+
+export const GoogleFonts: React.FC<IGoogleFontsProps> = (props) =>
+  props?.future?.withoutHead ? (
+    <GoogleFontsTags {...props} />
+  ) : (
+    <Head>
+      <GoogleFontsTags {...props} />
+    </Head>
+  );


### PR DESCRIPTION
Allow consumers to opt-in to (possibly unstable) breaking changes ahead of time 